### PR TITLE
AIQ-6337 updating play plugin to handle pants 1.3.0

### DIFF
--- a/src/python/play/BUILD
+++ b/src/python/play/BUILD
@@ -5,7 +5,7 @@ python_library(
   ],
   provides = setup_py(
     name = 'thesamet.playpants',
-    version = '0.1.2',
+    version = '0.2.0',
     description = 'Play plugin for Pants',
     url = 'https://github.com/thesamet/playpants',
     author = 'Nadav Sr. Samet',

--- a/src/python/play/BUILD
+++ b/src/python/play/BUILD
@@ -4,12 +4,12 @@ python_library(
   dependencies = [
   ],
   provides = setup_py(
-    name = 'thesamet.playpants',
+    name = 'com.actioniq.playpants',
     version = '0.2.0',
     description = 'Play plugin for Pants',
-    url = 'https://github.com/thesamet/playpants',
-    author = 'Nadav Sr. Samet',
-    author_email = 'nadav@thesamet.com',
+    url = 'https://github.com/ActionIQ/play-pants',
+    author = 'Alex Moore',
+    author_email = 'alex@actioniq.com',
     license = 'Apache License, Version 2.0',
     zip_safe = True,
     classifiers = [

--- a/src/python/play/BUILD
+++ b/src/python/play/BUILD
@@ -5,7 +5,7 @@ python_library(
   ],
   provides = setup_py(
     name = 'com.actioniq.playpants',
-    version = '0.2.0',
+    version = '0.2.1',
     description = 'Play plugin for Pants',
     url = 'https://github.com/ActionIQ/play-pants',
     author = 'Nadav Sr. Samet, Alex Moore, Nitay Joffe',

--- a/src/python/play/BUILD
+++ b/src/python/play/BUILD
@@ -8,7 +8,7 @@ python_library(
     version = '0.2.0',
     description = 'Play plugin for Pants',
     url = 'https://github.com/ActionIQ/play-pants',
-    author = 'Alex Moore',
+    author = 'Nadav Sr. Samet, Alex Moore, Nitay Joffe',
     author_email = 'alex@actioniq.com',
     license = 'Apache License, Version 2.0',
     zip_safe = True,

--- a/src/python/play/tasks/routes_gen.py
+++ b/src/python/play/tasks/routes_gen.py
@@ -4,8 +4,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
-from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.task.simple_codegen_task import SimpleCodegenTask
+from pants.java.jar.jar_dependency import JarDependency
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot

--- a/src/python/play/tasks/twirl_gen.py
+++ b/src/python/play/tasks/twirl_gen.py
@@ -4,8 +4,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
-from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.task.simple_codegen_task import SimpleCodegenTask
+from pants.java.jar.jar_dependency import JarDependency
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot


### PR DESCRIPTION
- The `SimpleCodeGen` task was moved in the 1.3.0 Pants distribution
- `backend.jvm.targets.jar_dependency` was deprecated in favor of `java.jar.jar_dependency`

Tested this all locally by editing cached files.